### PR TITLE
Raid poll & overview improvements/fixes

### DIFF
--- a/logic/get_overview.php
+++ b/logic/get_overview.php
@@ -7,7 +7,7 @@
  */
 function get_overview( $active_raids, $chat_id )
 {
-    global $config;
+    global $config, $eggs;
 
     // Get info about chat for username.
     debug_log('Getting chat object for chat_id: ' . $chat_id);
@@ -62,7 +62,10 @@ function get_overview( $active_raids, $chat_id )
                 // Add time left message.
                 $msg .= $pokemon . ' — <b>' . getPublicTranslation('still') . SP . $time_left . 'h</b>' . CR;
             }
-
+            $exclude_pokemon_sql = "";
+            if(!in_array($row['pokemon'], $eggs)) {
+                $exclude_pokemon_sql = 'AND (pokemon = \''.$row['pokemon'].'-'.$row['pokemon_form'].'\' or pokemon = \'0\')';
+            }
             // Count attendances
             $rs_att = my_query(
             "
@@ -80,6 +83,7 @@ function get_overview( $active_raids, $chat_id )
                           AND ( attend_time > UTC_TIMESTAMP() or attend_time = '" . ANYTIME . "' )
                           AND raid_done != 1
                           AND cancel != 1
+                          {$exclude_pokemon_sql}
                         ) as attendance
             LEFT JOIN   users
             ON          attendance.user_id = users.user_id

--- a/logic/get_overview.php
+++ b/logic/get_overview.php
@@ -7,7 +7,7 @@
  */
 function get_overview( $active_raids, $chat_id )
 {
-    global $config, $eggs;
+    global $config;
 
     // Get info about chat for username.
     debug_log('Getting chat object for chat_id: ' . $chat_id);
@@ -63,7 +63,7 @@ function get_overview( $active_raids, $chat_id )
                 $msg .= $pokemon . ' — <b>' . getPublicTranslation('still') . SP . $time_left . 'h</b>' . CR;
             }
             $exclude_pokemon_sql = "";
-            if(!in_array($row['pokemon'], $eggs)) {
+            if(!in_array($row['pokemon'], $GLOBALS['eggs'])) {
                 $exclude_pokemon_sql = 'AND (pokemon = \''.$row['pokemon'].'-'.$row['pokemon_form'].'\' or pokemon = \'0\')';
             }
             // Count attendances

--- a/logic/keys_vote.php
+++ b/logic/keys_vote.php
@@ -517,20 +517,14 @@ function keys_vote($raid)
                 $buttons_pokemon = [];
 
                 // Hide keys for specific cases
-                $show_keys = true;
+                $show_pokemon_keys = true;
                 // Make sure raid boss is not an egg
                 if(!in_array($raid_pokemon_id, $GLOBALS['eggs'])) {
-                    // Make sure we either have no participants
-                    // OR all participants voted for "any" raid boss
-                    // OR all participants voted for the hatched raid boss
-                    // OR all participants voted for "any" or the hatched raid boss
-                    if($count_pp == 0 || $count_pp == $count_any_pokemon || $count_pp == $count_raid_pokemon || $count_pp == ($count_any_pokemon + $count_raid_pokemon)) {
-                        $show_keys = false;
-                    }
+                    $show_pokemon_keys = false;
                 }
 
                 // Add pokemon keys if we found the raid boss
-                if ($raid_level != '0' && $show_keys) {
+                if ($raid_level != '0' && $show_pokemon_keys) {
                     // Get pokemon from database
                     $rs = my_query(
                         "

--- a/logic/show_raid_poll.php
+++ b/logic/show_raid_poll.php
@@ -6,7 +6,7 @@
  */
 function show_raid_poll($raid)
 {
-    global $config, $eggs;
+    global $config;
     // Init empty message array.
     //$msg = '';
     $msg = array();
@@ -98,7 +98,7 @@ function show_raid_poll($raid)
     // Remaining attendances are combined and treated as users that voted for any pokemon from now on
     $order_by_sql = 'pokemon,';
     $combine_attendances = false;
-    if(!in_array($raid['pokemon'], $eggs)) {
+    if(!in_array($raid['pokemon'], $GLOBALS['eggs'])) {
         $hide_users_sql.= 'AND (pokemon = \''.$raid['pokemon'].'-'.$raid['pokemon_form'].'\' OR pokemon = \'0\')';
         $order_by_sql = ''; // Remove sorting by pokemon since all attendances are combined
         $combine_attendances = true;

--- a/logic/show_raid_poll.php
+++ b/logic/show_raid_poll.php
@@ -92,8 +92,10 @@ function show_raid_poll($raid)
     } else {
         $hide_users_sql = "";
     }
+    $order_by_sql = 'pokemon,'; // For invite beggars
     if(!in_array($raid['pokemon'], $eggs)) {
         $hide_users_sql.= 'AND (pokemon = \''.$raid['pokemon'].'-'.$raid['pokemon_form'].'\' OR pokemon = \'0\')';
+        $order_by_sql = ''; // Remove sorting by pokemon for invite beggars, since all attendances are combined
     }
 
     // Buttons for raid levels and pokemon hidden?
@@ -226,10 +228,10 @@ function show_raid_poll($raid)
           AND           want_invite = 1
           AND           cancel = 0
           AND           raid_done = 0
-                        $hide_users_sql
+                        {$hide_users_sql}
             AND         attend_time IS NOT NULL
           ORDER BY      attend_time,
-                        pokemon,
+                        {$order_by_sql}
                         attendance.id
         "
     );

--- a/logic/show_raid_poll.php
+++ b/logic/show_raid_poll.php
@@ -227,14 +227,19 @@ function show_raid_poll($raid)
     }
     foreach($cnt_array as $time => $att_time_row) {
         if($att_time_row['other_pokemon'] == 0) {
-            foreach($cnt_array[$time][$raid_pokemon] as $title=>$value) {
-                $cnt_array[$time][0][$title]+=$value;
-                unset($cnt_array[$time][$raid_pokemon][$title]);
+            if(isset($cnt_array[$time][$raid_pokemon])) {
+                foreach($cnt_array[$time][$raid_pokemon] as $title=>$value) {
+                    $cnt_array[$time][0][$title]+=$value;
+                    unset($cnt_array[$time][$raid_pokemon][$title]);
+                }
             }
-            foreach($att_array[$time][$raid_pokemon] as $a_row) {
-                $att_array[$time][0][] = $a_row;
+            if(isset($att_array[$time][$raid_pokemon])) {
+                foreach($att_array[$time][$raid_pokemon] as $a_row) {
+                    $att_array[$time][0][] = $a_row;
+                }
+                unset($att_array[$time][$raid_pokemon]);
             }
-            unset($att_array[$time][$raid_pokemon]);
+            array_multisort(array_column($att_array[$time][0], 'team'),SORT_ASC,array_column($att_array[$time][0], 'arrived'),SORT_ASC,array_column($att_array[$time][0], 'level'),SORT_DESC,array_column($att_array[$time][0], 'name'),SORT_ASC,$att_array[$time][0]);
         }
     }
     // Raid has started and has participants

--- a/logic/show_raid_poll.php
+++ b/logic/show_raid_poll.php
@@ -6,7 +6,7 @@
  */
 function show_raid_poll($raid)
 {
-    global $config;
+    global $config, $eggs;
     // Init empty message array.
     //$msg = '';
     $msg = array();
@@ -92,7 +92,7 @@ function show_raid_poll($raid)
     } else {
         $hide_users_sql = "";
     }
-    if($raid['pokemon'] < '9990') {
+    if(!in_array($raid['pokemon'], $eggs)) {
         $hide_users_sql.= 'AND (pokemon = \''.$raid['pokemon'].'-'.$raid['pokemon_form'].'\' OR pokemon = \'0\')';
     }
 

--- a/logic/show_raid_poll.php
+++ b/logic/show_raid_poll.php
@@ -110,7 +110,13 @@ function show_raid_poll($raid)
         SELECT          attendance.*,
                         users.name,
                         users.level,
-                        users.team
+                        users.team,
+                        CASE
+                            WHEN users.team = 'mystic'  THEN 1
+                            WHEN users.team = 'valor'   THEN 2
+                            WHEN users.team = 'instinct'THEN 3
+                            ELSE 0
+                        END as sort_team
         FROM            attendance
         LEFT JOIN       users
           ON            attendance.user_id = users.user_id
@@ -206,7 +212,13 @@ function show_raid_poll($raid)
         SELECT          attendance.*,
                         users.name,
                         users.level,
-                        users.team
+                        users.team,
+                        CASE
+                            WHEN users.team = 'mystic'  THEN 1
+                            WHEN users.team = 'valor'   THEN 2
+                            WHEN users.team = 'instinct'THEN 3
+                            ELSE 0
+                        END as sort_team
         FROM            attendance
         LEFT JOIN       users
           ON            attendance.user_id = users.user_id
@@ -221,13 +233,6 @@ function show_raid_poll($raid)
                         attendance.id
         "
     );
-    while ($attendance = $rs_attendance_want_inv->fetch()) {
-        // Attendance found
-        $cnt_want_invite = 1;
-
-        // Fill attendance array with results
-        $att_array[$attendance['attend_time']][$attendance['pokemon']][] = $attendance;
-    }
     // Combine and sort array data if only both raid pokemon and any pokemon were selected per timeslot
     foreach($cnt_array as $time => $att_time_row) {
         if($att_time_row['other_pokemon'] == 0 && $att_time_row['raid_pokemon'] != 0) {
@@ -243,7 +248,18 @@ function show_raid_poll($raid)
             }
             unset($att_array[$time][$raid_pokemon]);
             // ...and sort the new list
-            array_multisort(array_column($att_array[$time][0], 'team'),SORT_ASC,array_column($att_array[$time][0], 'arrived'),SORT_ASC,array_column($att_array[$time][0], 'level'),SORT_DESC,array_column($att_array[$time][0], 'name'),SORT_ASC,$att_array[$time][0]);
+            array_multisort(array_column($att_array[$time][0], 'sort_team'),SORT_ASC,array_column($att_array[$time][0], 'arrived'),SORT_ASC,array_column($att_array[$time][0], 'level'),SORT_DESC,array_column($att_array[$time][0], 'name'),SORT_ASC,$att_array[$time][0]);
+        }
+    }
+    while ($attendance = $rs_attendance_want_inv->fetch()) {
+        // Attendance found
+        $cnt_want_invite = 1;
+
+        // Fill attendance array with results
+        if($cnt_array[$attendance['attend_time']]['other_pokemon'] == 0 && $cnt_array[$attendance['attend_time']]['raid_pokemon'] != 0) {
+            $att_array[$attendance['attend_time']][0][] = $attendance;
+        }else {
+            $att_array[$attendance['attend_time']][$attendance['pokemon']][] = $attendance;
         }
     }
     // Raid has started and has participants

--- a/logic/show_raid_poll.php
+++ b/logic/show_raid_poll.php
@@ -225,20 +225,20 @@ function show_raid_poll($raid)
         // Fill attendance array with results
         $att_array[$attendance['attend_time']][$attendance['pokemon']][] = $attendance;
     }
+    // Combine and sort array data if only both raid pokemon and any pokemon were selected per timeslot
     foreach($cnt_array as $time => $att_time_row) {
-        if($att_time_row['other_pokemon'] == 0) {
-            if(isset($cnt_array[$time][$raid_pokemon])) {
-                foreach($cnt_array[$time][$raid_pokemon] as $title=>$value) {
-                    $cnt_array[$time][0][$title]+=$value;
-                    unset($cnt_array[$time][$raid_pokemon][$title]);
-                }
+        if($att_time_row['other_pokemon'] == 0 && $att_time_row['raid_pokemon'] != 0) {
+            // Combine count data
+            foreach($cnt_array[$time][$raid_pokemon] as $title=>$value) {
+                $cnt_array[$time][0][$title]+=$value;
+                unset($cnt_array[$time][$raid_pokemon][$title]);
             }
-            if(isset($att_array[$time][$raid_pokemon])) {
-                foreach($att_array[$time][$raid_pokemon] as $a_row) {
-                    $att_array[$time][0][] = $a_row;
-                }
-                unset($att_array[$time][$raid_pokemon]);
+            // Combine user list from raid pokemon to any pokemon...
+            foreach($att_array[$time][$raid_pokemon] as $a_row) {
+                $att_array[$time][0][] = $a_row;
             }
+            unset($att_array[$time][$raid_pokemon]);
+            // ...and sort the new list
             array_multisort(array_column($att_array[$time][0], 'team'),SORT_ASC,array_column($att_array[$time][0], 'arrived'),SORT_ASC,array_column($att_array[$time][0], 'level'),SORT_DESC,array_column($att_array[$time][0], 'name'),SORT_ASC,$att_array[$time][0]);
         }
     }

--- a/logic/show_raid_poll.php
+++ b/logic/show_raid_poll.php
@@ -92,6 +92,9 @@ function show_raid_poll($raid)
     } else {
         $hide_users_sql = "";
     }
+    if($raid['pokemon'] < '9990') {
+        $hide_users_sql.= 'AND (pokemon = \''.$raid['pokemon'].'-'.$raid['pokemon_form'].'\' OR pokemon = \'0\')';
+    }
 
     // Buttons for raid levels and pokemon hidden?
     $hide_buttons_raid_level = explode(',', $config->RAID_POLL_HIDE_BUTTONS_RAID_LEVEL);

--- a/logic/show_raid_poll.php
+++ b/logic/show_raid_poll.php
@@ -115,7 +115,7 @@ function show_raid_poll($raid)
         LEFT JOIN       users
           ON            attendance.user_id = users.user_id
           WHERE         raid_id = {$raid['id']}
-                        $hide_users_sql
+                        {$hide_users_sql}
             AND         attend_time IS NOT NULL
           ORDER BY      attend_time,
                         pokemon,
@@ -232,8 +232,9 @@ function show_raid_poll($raid)
     foreach($cnt_array as $time => $att_time_row) {
         if($att_time_row['other_pokemon'] == 0 && $att_time_row['raid_pokemon'] != 0) {
             // Combine count data
+            if(!isset($cnt_array[$time][0])) $cnt_array[$time][0] = [];
             foreach($cnt_array[$time][$raid_pokemon] as $title=>$value) {
-                $cnt_array[$time][0][$title]+=$value;
+                $cnt_array[$time][0][$title] = (isset($cnt_array[$time][0][$title]) ? $cnt_array[$time][0][$title] + $value : $value);
                 unset($cnt_array[$time][$raid_pokemon][$title]);
             }
             // Combine user list from raid pokemon to any pokemon...

--- a/logic/show_raid_poll.php
+++ b/logic/show_raid_poll.php
@@ -225,6 +225,18 @@ function show_raid_poll($raid)
         // Fill attendance array with results
         $att_array[$attendance['attend_time']][$attendance['pokemon']][] = $attendance;
     }
+    foreach($cnt_array as $time => $att_time_row) {
+        if($att_time_row['other_pokemon'] == 0) {
+            foreach($cnt_array[$time][$raid_pokemon] as $title=>$value) {
+                $cnt_array[$time][0][$title]+=$value;
+                unset($cnt_array[$time][$raid_pokemon][$title]);
+            }
+            foreach($att_array[$time][$raid_pokemon] as $a_row) {
+                $att_array[$time][0][] = $a_row;
+            }
+            unset($att_array[$time][$raid_pokemon]);
+        }
+    }
     // Raid has started and has participants
     if($time_now > $raid['start_time'] && $cnt_all > 0) {
         // Display raid boss CP values.

--- a/mods/raid_set_poke.php
+++ b/mods/raid_set_poke.php
@@ -23,23 +23,6 @@ my_query(
     "
 );
 
-// Get eggs.
-$eggs = $GLOBALS['eggs'];
-
-// Do not update if pokedex_id is an egg.
-if(!in_array($pokemon_id_form[0], $eggs)) {
-    // Update users in attendance table.
-    // Helps to proper sort users as they are ordered by pokemon.
-    my_query(
-        "
-        UPDATE    attendance
-        SET       pokemon = '{$data['arg']}'
-          WHERE   raid_id = {$id}
-          AND     pokemon = '0'
-        "
-    );
-}
-
 // Get raid times.
 $raid = get_raid($data['id']);
 

--- a/mods/vote_time.php
+++ b/mods/vote_time.php
@@ -86,7 +86,10 @@ if($now <= $attend_time || $vote_time == 0) {
         if (!empty($answer)) {
             // Update attendance.
             alarm($data['id'],$update['callback_query']['from']['id'],'change_time', $attend_time);
-            if($raid['pokemon'] < '9990') {
+            if(!in_array($raid['pokemon'], $eggs)) {
+                // If raid egg has hatched
+                // -> clean up attendance table from votes for other pokemon
+                // -> leave one entry remaining and set the pokemon to 0 there
                 my_query("
                     DELETE  a1
                     FROM    attendance a1,

--- a/mods/vote_time.php
+++ b/mods/vote_time.php
@@ -86,6 +86,7 @@ if($now <= $attend_time || $vote_time == 0) {
         if (!empty($answer)) {
             // Update attendance.
             alarm($data['id'],$update['callback_query']['from']['id'],'change_time', $attend_time);
+            $update_pokemon_sql = '';
             if(!in_array($raid['pokemon'], $eggs)) {
                 // If raid egg has hatched
                 // -> clean up attendance table from votes for other pokemon


### PR DESCRIPTION
- Changed raid poll and overview to hide all votes for other pokemon than 'any pokemon' and the pokemon that hatched.
- Fixed some PHP notices caused by undefined variables.
- Removed function get_gym_raid as unnecessary. We already have get_raid that does the same thing and more.