### PR TITLE
Fixes

### DIFF
--- a/mods/raid_share.php
+++ b/mods/raid_share.php
@@ -47,8 +47,8 @@ $raid_picture_hide_level = explode(",",$config->RAID_PICTURE_HIDE_LEVEL);
 $raid_picture_hide_pokemon = explode(",",$config->RAID_PICTURE_HIDE_POKEMON);
 
 $raid_pokemon_id = $raid['pokemon'];
-$raid_level = get_raid_level($raid['pokemon'], $raid['pokemon_form']);
-$raid_pokemon_form_name = get_pokemon_form_name($raid_pokemon_id,$raid['pokemon_form_id']);
+$raid_level = $raid['level'];
+$raid_pokemon_form_name = get_pokemon_form_name($raid_pokemon_id,$raid['pokemon_form']);
 $raid_pokemon = $raid_pokemon_id . "-" . $raid_pokemon_form_name;
 
 if($config->RAID_PICTURE && !in_array($raid_level, $raid_picture_hide_level) && !in_array($raid_pokemon, $raid_picture_hide_pokemon) && !in_array($raid_pokemon_id, $raid_picture_hide_pokemon)) {


### PR DESCRIPTION
- `get_raid()` already provides raid level, no need to look it up again
- Fixed the pokemon form variable name. This was causing PHP notices